### PR TITLE
CI: pass GITHUB_TOKEN to the New-PR script

### DIFF
--- a/.github/workflows/ide-updater.yml
+++ b/.github/workflows/ide-updater.yml
@@ -33,6 +33,7 @@ jobs:
         shell: pwsh
         run: ./scripts/New-PR.ps1 -BranchName $env:BRANCH_NAME -CommitMessage $env:COMMIT_MESSAGE -PrTitle $env:PR_TITLE -PrBodyPath $env:PR_BODY_PATH
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: ${{ steps.update.outputs.branch-name }}
           COMMIT_MESSAGE: ${{ steps.update.outputs.commit-message }}
           PR_TITLE: ${{ steps.update.outputs.pr-title }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,14 @@ jobs:
           path: ${{ runner.os == 'Windows' && '~/AppData/Local/JetBrains/dotnet-cmd' || '~/.local/share/JetBrains/dotnet-cmd' }}
           key: ${{ runner.os }}-dotnet-${{ hashFiles('dotnet.cmd') }}
 
+      - name: 'Cache downloaded JDK'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.local/share/gradle-jvm
+            ~/AppData/Local/gradle-jvm
+          key: ${{ runner.os }}-${{ hashFiles('gradlew*') }}
+
       # Common preparation
       - name: Prepare build
         run: ./gradlew prepare


### PR DESCRIPTION
Should fix the IDE updater workflow.