### PR TITLE
Gradle build script update: improvements to the two-stage build process with a signing in the middle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jetbrains.intellij.platform.gradle.Constants
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import kotlin.io.path.absolute
+import java.util.zip.ZipFile
 import kotlin.io.path.isDirectory
 
 plugins {
@@ -28,47 +29,6 @@ repositories {
         defaultRepositories()
         jetbrainsRuntime()
     }
-}
-
-val pluginVersion: String by project
-val untilBuildVersion: String by project
-val buildConfiguration: String by project
-val dotNetPluginId: String by project
-
-version = pluginVersion
-
-// ============ Plugin File Definitions (Single Source of Truth) ==============
-
-val pluginStagingDir = layout.buildDirectory.dir("plugin-staging").get().asFile
-val pluginContentDir = file("${pluginStagingDir}/${rootProject.name}")
-val signingManifestFile = file("${pluginStagingDir}/files-to-sign.txt")
-
-val dotNetSrcDir = File(projectDir, "src/dotnet")
-val dotNetOutputDir = "$dotNetSrcDir/$dotNetPluginId/bin/$dotNetPluginId/$buildConfiguration"
-
-// All .NET files to include in the plugin
-val dotNetOutputFiles = listOf(
-    "${dotNetPluginId}.dll",
-    "${dotNetPluginId}.pdb",
-)
-
-// .NET files that need signing (only our own code)
-val dotNetFilesToSign = listOf(
-    "${dotNetPluginId}.dll",
-)
-
-// JAR files that need signing (only our own code)
-// Note: no searchable options JAR because buildSearchableOptions = false
-val jarFilesToSign = listOf(
-    "${rootProject.name}-${version}.jar",
-)
-
-val riderSdkPath by lazy {
-    val path = intellijPlatform.platformPath.resolve("lib/DotNetSdkForRdPlugins").absolute()
-    if (!path.isDirectory()) error("$path does not exist or not a directory")
-
-    println("Rider SDK path: $path")
-    return@lazy path
 }
 
 dependencies {
@@ -96,6 +56,49 @@ dependencies {
 intellijPlatform {
     this.instrumentCode = false
     this.buildSearchableOptions = false
+}
+
+val pluginVersion: String by project
+val untilBuildVersion: String by project
+val buildConfiguration: String by project
+val dotNetPluginId: String by project
+
+version = pluginVersion
+
+// ============ Plugin File Definitions (Single Source of Truth) ==============
+
+val pluginStagingDir = layout.buildDirectory.dir("plugin-staging").get().asFile
+val pluginStagingContentDir = file("${pluginStagingDir}/${rootProject.name}")
+val signingManifestFile = file("${pluginStagingDir}/files-to-sign.txt")
+
+val dotNetSrcDir = File(projectDir, "src/dotnet")
+val dotNetOutputDir = "$dotNetSrcDir/$dotNetPluginId/bin/$dotNetPluginId/$buildConfiguration"
+
+// All .NET files to include in the plugin
+val dotNetOutputFiles = listOf(
+    "${dotNetPluginId}.dll",
+    "${dotNetPluginId}.pdb",
+)
+
+// .NET files that need signing (only our own code)
+val dotNetFilesToSign = listOf(
+    "${dotNetPluginId}.dll",
+)
+
+// JAR files that need signing (only our own code)
+val jarFilesToSign = mutableListOf<String>().apply {
+    add("${rootProject.name}-${version}.jar")
+    if (intellijPlatform.buildSearchableOptions.get()) {
+        add("${rootProject.name}-${version}-searchableOptions.jar")
+    }
+}.toList()
+
+val riderSdkPath by lazy {
+    val path = intellijPlatform.platformPath.resolve("lib/DotNetSdkForRdPlugins").absolute()
+    if (!path.isDirectory()) error("$path does not exist or not a directory")
+
+    println("Rider SDK path: $path")
+    return@lazy path
 }
 
 
@@ -236,119 +239,135 @@ tasks {
     runIde {
         jvmArgs("-Xmx1500m")
     }
-}
 
-// ========= Two-Phase Build for Signing Support ================
+    // ========= Two-Phase Build for Signing Support ================
 
-// Preparation for signing. Build all dll's and jar's and puts them into ${pluginStagingDir}
-val preparePluginForSigning by tasks.registering(Sync::class) {
-    description = "Prepares plugin files for signing and generates signing manifest"
-    group = "build"
+    // Preparation for plugin internals signing. Build all dll's and jar's and puts them into ${pluginStagingDir}
+    val preparePluginInternalsForSigning by registering(Sync::class) {
+        description = "Prepares plugin files for signing and generates signing manifest"
+        group = "build"
 
-    // Source 1: Copy the full plugin directory from prepareSandbox
-    from(tasks.prepareSandbox.map { it.pluginDirectory })
+        // Source 1: Copy the full plugin directory from prepareSandbox
+        from(prepareSandbox.map { it.pluginDirectory })
 
-    // Source 2: Copy searchable options JAR to lib/ (when enabled)
-    if (intellijPlatform.buildSearchableOptions.get()) {
-        from(tasks.jarSearchableOptions.map { it.archiveFile }) {
-            into("lib")
+        // Source 2: Copy searchable options JAR to lib/ (when enabled)
+        if (intellijPlatform.buildSearchableOptions.get()) {
+            from(jarSearchableOptions.map { it.archiveFile }) {
+                into("lib")
+            }
+        }
+
+        // Destination: the plugin content directory inside staging
+        into(pluginStagingContentDir)
+
+        // Capture script-level vals into locals to avoid error with gradle task cache
+        val signingManifestFile = signingManifestFile
+        val pluginStagingDir = pluginStagingDir
+        val jarFilesToSign = jarFilesToSign
+        val projectName = rootProject.name
+
+        // After syncing, generate the signing manifest
+        doLast {
+            val filesToSign = mutableListOf<String>()
+
+            // Add JAR files that need signing (only our own code)
+            jarFilesToSign.forEach { jarName ->
+                filesToSign.add("${projectName}/lib/${jarName}")
+            }
+
+            // Add .NET files that need signing
+            dotNetFilesToSign.forEach { fileName ->
+                filesToSign.add("${projectName}/dotnet/${fileName}")
+            }
+
+            // Write manifest
+            signingManifestFile.writeText(filesToSign.joinToString("\n"))
+
+            // Summary
+            println("Plugin prepared for signing: ${pluginStagingDir}")
+            println("Signing manifest: ${signingManifestFile}")
+            println("Files to sign: ${filesToSign.size}")
+            filesToSign.forEach { println("  - $it") }
         }
     }
 
-    // Destination: the plugin content directory inside staging
-    into(pluginContentDir)
+    // Validates that ${pluginStagingDir} has all required files to assemble the plugin
+    val validatePluginStaging by registering {
+        description = "Validates that plugin staging directory exists and contains required files"
+        group = "build"
 
-    // After syncing, generate the signing manifest
-    doLast {
-        val filesToSign = mutableListOf<String>()
+        // Capture script-level vals into locals to avoid error with gradle task cache
+        val pluginStagingContentDir = pluginStagingContentDir
+        val jarFilesToSign = jarFilesToSign
 
-        // Add JAR files that need signing (only our own code)
-        jarFilesToSign.forEach { jarName ->
-            filesToSign.add("${rootProject.name}/lib/${jarName}")
-        }
+        doLast {
+            if (!pluginStagingContentDir.exists()) {
+                throw RuntimeException(
+                    "Plugin staging directory not found: ${pluginStagingContentDir}\n" +
+                    "Run './gradlew preparePluginInternalsForSigning' first."
+                )
+            }
 
-        // Add .NET files that need signing
-        dotNetFilesToSign.forEach { fileName ->
-            filesToSign.add("${rootProject.name}/dotnet/${fileName}")
-        }
+            // Validate expected .NET output files exist
+            dotNetOutputFiles.forEach { fileName ->
+                val file = pluginStagingContentDir.resolve("dotnet/${fileName}")
+                if (!file.exists()) throw RuntimeException("Expected .NET file not found: ${file}")
+            }
 
-        // Write manifest
-        signingManifestFile.writeText(filesToSign.joinToString("\n"))
-
-        // Summary
-        println("Plugin prepared for signing: ${pluginStagingDir}")
-        println("Signing manifest: ${signingManifestFile}")
-        println("Files to sign: ${filesToSign.size}")
-        filesToSign.forEach { println("  - $it") }
-    }
-}
-
-// Validates that ${pluginStagingDir} has all required files to assemble the plugin
-val validatePluginStaging by tasks.registering {
-    description = "Validates that plugin staging directory exists and contains required files"
-    group = "build"
-
-    doLast {
-        if (!pluginContentDir.exists()) {
-            throw RuntimeException(
-                "Plugin staging directory not found: ${pluginContentDir}\n" +
-                "Run './gradlew preparePluginForSigning' first."
-            )
-        }
-
-        // Validate expected .NET output files exist
-        dotNetOutputFiles.forEach { fileName ->
-            val file = file("${pluginContentDir}/dotnet/${fileName}")
-            if (!file.exists()) throw RuntimeException("Expected .NET file not found: ${file}")
-        }
-
-        // Validate expected JAR files exist
-        jarFilesToSign.forEach { jarName ->
-            val file = file("${pluginContentDir}/lib/${jarName}")
-            if (!file.exists()) throw RuntimeException("Expected JAR file not found: ${file}")
+            // Validate expected JAR files exist
+            jarFilesToSign.forEach { jarName ->
+                val file = pluginStagingContentDir.resolve("lib/${jarName}")
+                if (!file.exists()) throw RuntimeException("Expected JAR file not found: ${file}")
+            }
         }
     }
-}
 
-// Assembles the final zip-archive by taking the files from ${pluginStagingDir}
-val assemblePlugin by tasks.registering(Zip::class) {
-    description = "Assembles the final plugin ZIP from staged files"
-    group = "build"
+    // Assembles the final zip-archive from staged (potentially externally signed) files.
+    // Produces a ZIP with "-from-staging" suffix by default (override with -PoutputPluginFileSuffix=<value>)
+    // Can be used in pipeline: preparePluginInternalsForSigning -> external sign -> assemblePlugin
+    val assemblePlugin by registering(Zip::class) {
+        description = "Assembles the plugin ZIP from staged files with '-from-staging' classifier"
+        group = "build"
 
-    dependsOn(validatePluginStaging)
+        dependsOn(validatePluginStaging)
 
-    from(pluginStagingDir) {
-        // Include plugin content directory
+        from(pluginStagingDir)
         include("${rootProject.name}/**")
-        // Exclude signing manifest from final ZIP
         exclude("files-to-sign.txt")
+
+        archiveBaseName.convention(intellijPlatform.projectName)
+        archiveClassifier.set(providers.gradleProperty("outputPluginFileSuffix").orElse("from-staging"))
+        destinationDirectory.set(layout.buildDirectory.dir("distributions"))
     }
 
-    // Use same naming convention as original BuildPluginTask:
-    // archiveBaseName comes from plugin.xml (via IntelliJ plugin extension)
-    archiveBaseName.convention(intellijPlatform.projectName)
-    destinationDirectory.set(layout.buildDirectory.dir("distributions"))
+    // ==============================================================
 
-    // Register artifact to INTELLIJ_PLATFORM_DISTRIBUTION configuration (same as original BuildPluginTask)
-    // This ensures publishPlugin and other dependent tasks can find the archive
-    val intellijPlatformDistributionConfiguration =
-        configurations[Constants.Configurations.INTELLIJ_PLATFORM_DISTRIBUTION]
-    artifacts.add(intellijPlatformDistributionConfiguration.name, this)
-}
+    // buildPlugin keeps its default Zip behavior (sources from prepareSandbox + jarSearchableOptions).
+    // We add dependsOn(preparePluginInternalsForSigning) to ensure the staging directory is populated,
+    // then verify the archive matches the staging directory.
+    buildPlugin {
+        // Ensure that the staging directory is populated
+        dependsOn(preparePluginInternalsForSigning)
 
-tasks.buildPlugin {
-    // Disable the IntelliJ plugin's default buildPlugin behavior for ZIP creation
-    // and make it use our two-phase approach instead
-    actions.clear()
+        val pluginStagingContentDir = pluginStagingContentDir
+        val projectName = rootProject.name
 
-    // Make it depend on our assembly task
-    dependsOn(preparePluginForSigning)
-    dependsOn(assemblePlugin)
+        doLast {
+            // Verify the archive matches the staging directory to be sure that
+            // buildPlugin and preparePluginInternalsForSigning+assemblePlugin produces the same results
+            val zipFiles = ZipFile(archiveFile.get().asFile).use {
+                it.entries().asSequence().filterNot { e -> e.isDirectory }.map { e -> e.name }.sorted().toList()
+            }
+            val stagingFiles = pluginStagingContentDir.walkTopDown().filter { it.isFile }
+                .map { "${projectName}/${it.relativeTo(pluginStagingContentDir).path.replace('\\', '/')}" }
+                .sorted().toList()
 
-    // Phase 2 (assemblePlugin + all its dependencies) must run after Phase 1
-    assemblePlugin.get().mustRunAfter(preparePluginForSigning)
-    assemblePlugin.get().taskDependencies.getDependencies(assemblePlugin.get()).forEach { task ->
-        task.mustRunAfter(preparePluginForSigning)
+            check(zipFiles == stagingFiles) {
+                "Plugin archive and staging directory are out of sync!\n" +
+                "  Only in archive: ${zipFiles - stagingFiles.toSet()}\n" +
+                "  Only in staging: ${stagingFiles - zipFiles.toSet()}"
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Build script update: `buildPlugin` task was rolled back to its original state to minimize problems with dependent tasks. Additional verification step added to `buildPlugin`. `preparePluginForSigning` renamed to `preparePluginInternalsForSigning`.

`intellij-platform-gradle-plugin` provides tasks for signing the archive itself and for publishing. And these tasks are strictly depends on original `buildPlugin` task. Previous implementation of the build script reimplemented the `buildPlugin` task, which will result in errors if someone decides to use the publishing task. My attempts to unwire tasks led to a large amount of hard to support code, that's why it is better to keep original version of `buildPlugin`. This approach was implemented for EzArgs plugin ( https://github.com/JetBrains/EzArgs/pull/50 ) and for EnhancedUnrealEngineDocumentation ( https://github.com/JetBrains/EnhancedUnrealEngineDocumentation/pull/30 ). It make sense to port these changes to this plugin too