### PR TITLE
CI: drop the maintainer note from the PRs

### DIFF
--- a/intellij-updater.json
+++ b/intellij-updater.json
@@ -22,6 +22,5 @@
         "versionFlavor": "release",
         "versionConstraint": "latestWave",
         "order": "oldest"
-    }],
-    "prBodyPrefix": "## Maintainer Note\n> [!WARNING]\n> This PR will not trigger CI by default. Please **close it and reopen manually** to trigger the CI.\n>\n> Unfortunately, this is a consequence of the current GitHub Action security model (by default, PRs created automatically aren't allowed to trigger other automation)."
+    }]
 }


### PR DESCRIPTION
The CI now works for them by default.