### PR TITLE
CI: disable kotlin-test automatic update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,4 @@ updates:
       - dependency-name: "com.jetbrains.rd:rd-gen"
       - dependency-name: "org.jetbrains.kotlin.jvm"
       - dependency-name: "org.jetbrains.kotlin:kotlin-stdlib"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-test"


### PR DESCRIPTION
It should be handled by intellij-updater automatically.

Closes #104.