### PR TITLE
Build: migrate to the modern build/verification routine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,8 +60,8 @@ jobs:
           path: "src/dotnet/Tests/TestResults/*.trx"
 
       # Frontend
-      - name: Build the plugin
-        run: ./gradlew build buildPlugin -PbuildConfiguration=Release
+      - name: Build and test the plugin
+        run: ./gradlew build -PbuildConfiguration=Release
 
       - if: matrix.image == 'ubuntu-22.04'
         id: version

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.changelog.exceptions.MissingVersionException
 import org.jetbrains.intellij.platform.gradle.Constants
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.models.ProductRelease
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.zip.ZipFile
 import kotlin.io.path.absolute
@@ -66,15 +67,27 @@ dependencies {
     testImplementation(libs.testng)
 }
 
-intellijPlatform {
-    this.instrumentCode = false
-    this.buildSearchableOptions = false
-}
-
 val pluginVersion: String by project
-val untilBuildVersion: String by project
+val untilBuildForVerification: String by project
 val buildConfiguration: String by project
 val dotNetPluginId: String by project
+
+intellijPlatform {
+    instrumentCode = false
+    buildSearchableOptions = false
+
+    pluginVerification {
+        ides {
+            select {
+                channels = listOf(
+                    ProductRelease.Channel.RELEASE,
+                    ProductRelease.Channel.EAP
+                )
+                untilBuild = untilBuildForVerification
+            }
+        }
+    }
+}
 
 version = pluginVersion
 
@@ -170,7 +183,6 @@ tasks {
     }
 
     patchPluginXml {
-        untilBuild.set(untilBuildVersion)
         val latestChangelog = try {
             changelog.getUnreleased()
         } catch (_: MissingVersionException) {
@@ -229,15 +241,9 @@ tasks {
         environment["LOCAL_ENV_RUN"] = "true"
     }
 
-    val testRiderPreview by intellijPlatformTesting.testIde.registering {
-        version = libs.versions.riderSdkPreview
-        useInstaller = false
-        task {
-            enabled = libs.versions.riderSdk.get() != libs.versions.riderSdkPreview.get()
-        }
+    check {
+        dependsOn(verifyPlugin)
     }
-
-    check { dependsOn(testRiderPreview.name) }
 
     runIde {
         jvmArgs("-Xmx1500m")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginVersion=1.3.0
 
-untilBuildVersion=262.*
+untilBuildForVerification=262.*
 
 buildConfiguration=Debug
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 kotlin = "2.3.20"
 rdGen = "2026.1.3"
 riderSdk = "2026.1.1"
-riderSdkPreview = "2026.1.1"
 
 [libraries]
 junit = "junit:junit:4.13.2"

--- a/intellij-updater.json
+++ b/intellij-updater.json
@@ -3,24 +3,17 @@
         "file": "gradle/libs.versions.toml",
         "field": "riderSdk",
         "kind": "rider",
-        "versionFlavor": "eap"
-    }, {
-        "file": "gradle/libs.versions.toml",
-        "field": "riderSdkPreview",
-        "kind": "rider",
-        "versionFlavor": "eap"
+        "versionFlavor": "release"
     }, {
         "file": "gradle.properties",
-        "field": "untilBuildVersion",
+        "field": "untilBuildForVerification",
         "kind": "rider",
-        "versionFlavor": "eap",
+        "versionFlavor": "release",
         "augmentation": "nextMajor"
     }, {
         "file": "gradle/libs.versions.toml",
         "field": "kotlin",
         "kind": "kotlin",
-        "versionFlavor": "release",
-        "versionConstraint": "latestWave",
-        "order": "oldest"
+        "versionFlavor": "release"
     }]
 }


### PR DESCRIPTION
We now build against the latest release and run verification against EAP.